### PR TITLE
Escape literal left braces in regular expressions

### DIFF
--- a/lib/Mac/Errors.pm
+++ b/lib/Mac/Errors.pm
@@ -100,7 +100,7 @@ constants();
 sub constants {
 	seek DATA, 0, 0; # this reads the entire script
 	my $data = do { local $/; <DATA> };
-	while( $data =~ m|=item (\w+)(?:\s+([^\n]+))?\n\s+?=cut\s+sub \1 { (-?\d+) }|g ) {
+	while( $data =~ m|=item (\w+)(?:\s+([^\n]+))?\n\s+?=cut\s+sub \1 \{ (-?\d+) }|g ) {
 		my( $symbol, $desc, $value ) = ( $1, $2, $3 );
 		push @EXPORT_OK, $symbol;
 		


### PR DESCRIPTION
With Perl 5.25.1 literal left braces became an error. This is a
continuation of the deprecation cycle that was begun with Perl 5.22.0,
where they produced a warning. The patched code works under Perls 5.25.1
and 5.24.0 (default build) under Mac OS 10.11.5.